### PR TITLE
update extension for gnome-shell 3.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ It installs a keybinding which defaults to <Super>escape. Repeatedly
 pressing <Super>escape causes the active workspace to toggle between
 the last two selected workspaces.
 
-Only tested with Gnome version 3.20.
+Only tested with Gnome version 3.30.

--- a/extension.js
+++ b/extension.js
@@ -17,7 +17,7 @@ function goToLastWorkspace() {
     return;
   }
 
-  let ws = global.screen.get_workspace_by_index(lastWorkspace);
+  let ws = global.workspace_manager.get_workspace_by_index(lastWorkspace);
   ws.activate(0);
 }
 
@@ -31,7 +31,7 @@ function enable() {
   var ModeType = Shell.hasOwnProperty('ActionMode') ? Shell.ActionMode : Shell.KeyBindingMode;
   Main.wm.addKeybinding(SHORTCUT_KEY, settings, Meta.KeyBindingFlags.NONE, ModeType.NORMAL | ModeType.OVERVIEW, goToLastWorkspace);
 
-  signals.push(global.screen.connect('workspace-switched', function(screen, prev, current, direction) {
+  signals.push(global.workspace_manager.connect('workspace-switched', function(display, prev, current, direction) {
     lastWorkspace = currentWorkspace;
     currentWorkspace = current;
   }));
@@ -43,9 +43,7 @@ function disable() {
   
   let i = signals.length;
   while (i--) {
-    global.screen.disconnect(signals.pop());
+    global.workspace_manager.disconnect(signals.pop());
   }
   
 }
-
-

--- a/extension.js
+++ b/extension.js
@@ -17,7 +17,8 @@ function goToLastWorkspace() {
     return;
   }
 
-  let ws = global.workspace_manager.get_workspace_by_index(lastWorkspace);
+  // keep global.screen for backwards compatibility
+  let ws = (global.screen || global.workspace_manager).get_workspace_by_index(lastWorkspace);
   ws.activate(0);
 }
 
@@ -31,7 +32,7 @@ function enable() {
   var ModeType = Shell.hasOwnProperty('ActionMode') ? Shell.ActionMode : Shell.KeyBindingMode;
   Main.wm.addKeybinding(SHORTCUT_KEY, settings, Meta.KeyBindingFlags.NONE, ModeType.NORMAL | ModeType.OVERVIEW, goToLastWorkspace);
 
-  signals.push(global.workspace_manager.connect('workspace-switched', function(display, prev, current, direction) {
+  signals.push((global.screen || global.workspace_manager).connect('workspace-switched', function(display, prev, current, direction) {
     lastWorkspace = currentWorkspace;
     currentWorkspace = current;
   }));
@@ -43,7 +44,7 @@ function disable() {
   
   let i = signals.length;
   while (i--) {
-    global.workspace_manager.disconnect(signals.pop());
+    (global.screen || global.workspace_manager).disconnect(signals.pop());
   }
   
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "Go To Last Workspace",
     "uuid": "gnome-shell-go-to-last-workspace@github.com",
-    "shell-version": ["3.20"],
+    "shell-version": ["3.30"],
     "description": "Quickly toggle between two workspaces with one key",
     "settings-schema": "org.gnome.shell.extensions.go-to-last-workspace"
 }


### PR DESCRIPTION
I have added some changes such that the extension works in gnome-shell 3.30. I don't know if it will work in older versions, though.