### PR TITLE
add supported versions up to Gnome 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Go To Last Workspace",
   "uuid": "gnome-shell-go-to-last-workspace@github.com",
-  "shell-version": ["3.32", "3.30", "3.28"],
+  "shell-version": ["40", "3.38" ,"3.36", "3.34", "3.32", "3.30", "3.28"],
   "description": "Quickly toggle between two workspaces with one key",
   "settings-schema": "org.gnome.shell.extensions.go-to-last-workspace",
   "version": 4


### PR DESCRIPTION
Tested with Gnome 40 on ARch Linux just now and it seems to work fine. Seems to have just worked before version 40 but as of 40 it won't load because Gnome complains that it is not compatible with version 40.