### PR TITLE
Gnome 41 + some additions

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,38 +1,66 @@
 const Meta = imports.gi.Meta;
 const Main = imports.ui.main;
 const Shell = imports.gi.Shell;
+const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 
 const SHORTCUT_KEY = 'shortcut-key';
 
 let settings = imports.misc.extensionUtils.getSettings();
 
-var currentWorkspace = -1;
 var lastWorkspace = -1;
+let workspacesSwitcherPopup;
+
+function getWorkspaceSwitcherPopup() {
+  if (!workspacesSwitcherPopup) {
+    workspacesSwitcherPopup = new WorkspaceSwitcherPopup.WorkspaceSwitcherPopup({
+      reactive: false,
+    });
+    workspacesSwitcherPopup.connect('destroy', () => {
+      workspacesSwitcherPopup = null;
+    });
+  }
+  return workspacesSwitcherPopup;
+}
+
+function getDirection() {
+  if (global.workspace_manager.get_active_workspace_index() > lastWorkspace) {
+    return Meta.MotionDirection.LEFT;
+  } else {
+    return Meta.MotionDirection.RIGHT;
+  }
+}
 
 function goToLastWorkspace() {
   if (lastWorkspace < 0) {
     return;
   }
-
-  // keep global.screen for backwards compatibility
-  let ws = (global.screen || global.workspace_manager).get_workspace_by_index(lastWorkspace);
-  ws.activate(global.get_current_time());
+  getWorkspaceSwitcherPopup().display(getDirection(), lastWorkspace);
+  const ws = global.workspace_manager.get_workspace_by_index(lastWorkspace);
+  Main.wm.actionMoveWorkspace(ws);
 }
 
-
-function init() {
-}
+function init() {}
 
 let signals = [];
 
 function enable() {
   var ModeType = Shell.hasOwnProperty('ActionMode') ? Shell.ActionMode : Shell.KeyBindingMode;
-  Main.wm.addKeybinding(SHORTCUT_KEY, settings, Meta.KeyBindingFlags.NONE, ModeType.NORMAL | ModeType.OVERVIEW, goToLastWorkspace);
+  Main.wm.addKeybinding(
+    SHORTCUT_KEY,
+    settings,
+    Meta.KeyBindingFlags.NONE,
+    ModeType.NORMAL | ModeType.OVERVIEW,
+    goToLastWorkspace,
+  );
 
-  signals.push((global.screen || global.workspace_manager).connect('workspace-switched', function(display, prev, current, direction) {
-    lastWorkspace = currentWorkspace;
-    currentWorkspace = current;
-  }));
+  signals.push(
+    (global.screen || global.workspace_manager).connect(
+      'workspace-switched',
+      function (display, prev, current, direction) {
+        lastWorkspace = prev;
+      },
+    ),
+  );
 }
 
 function disable() {
@@ -43,5 +71,4 @@ function disable() {
   while (i--) {
     (global.screen || global.workspace_manager).disconnect(signals.pop());
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Go To Last Workspace",
   "description": "Quickly toggle between two workspaces with one key",
   "url": "https://github.com/arjan/gnome-shell-go-to-last-workspace",
-  "version": 7,
-  "shell-version": ["40", "3.38", "3.36", "3.34", "3.32", "3.30", "3.28"],
+  "version": 8,
+  "shell-version": ["41", "40"],
   "settings-schema": "org.gnome.shell.extensions.go-to-last-workspace"
 }


### PR DESCRIPTION
- show workspace switcher
- use actionMoveWorkspace (compatibility to [Focus Follows Workspace
  extension][1])

I didn't test compatibility to anything other than Gnome 41.

[1]: https://github.com/christopher-l/focus-follows-workspace